### PR TITLE
SASS -> Sass

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -65,7 +65,7 @@ with a major version change, and documents breaking changes.
 <h2 id="unix-way">UNIX-way</h2>
 <p>Soupault aims to do one thing: manipulate HTML element trees offline, and do it well.</p>
 <p>
-It purposely doesn't include things like a development web server, a SASS compiler, or an image processing library.
+It purposely doesn't include things like a development web server, a Sass compiler, or an image processing library.
 It avoids bloating the executable with built-in functionality that only some users will want, and that some users will want
 to work <em>different from the built-in</em>.
 </p>


### PR DESCRIPTION
http://sassnotsass.com/
https://en.wikipedia.org/wiki/Sass_(stylesheet_language)

Sass is neither an acronym or initialism nor is stylized as SASS anywhere.