### PR TITLE
lean into the theme w/ theme-color & selection

### DIFF
--- a/site/main.css
+++ b/site/main.css
@@ -9,8 +9,10 @@
     --Pre-border: #aaa;
     --Main-color: #333;
     --Code-color: #1a8a66; /* teal */
-    --Accent1-color: #e31e23; /* red */
+    --Accent1-color: #e31e24; /* red */
     --Accent2-color: #d65906; /* orange */
+    --Selection-bg: #e31e24;
+    --Selection-color: #fff;
     /* from KWrite */
     --Highlight-num: #b07e00;
     --Highlight-esc: #ff00ff;
@@ -39,9 +41,8 @@
         --Pre-border: #222;
         --Main-color: #f2f2f2;
         --Code-color: #2adba4; /* teal */
-        --Accent1-color: #c90309; /* red */
+        --Accent1-color: #e31e24; /* red */
         --Accent2-color: #ef7f1a; /* orange */
-        --Accent2-hover: #ef7f1a;
         /* via @toastal */
         --Highlight-num: #43a60d;
         --Highlight-esc: #dfad06;
@@ -114,6 +115,12 @@ html
 header
 {
     text-align: center;
+}
+
+::selection 
+{
+    background: var(--Selection-bg);
+    color: var(--Selection-color);
 }
 
 /* shared gradient border */

--- a/templates/main.html
+++ b/templates/main.html
@@ -2,6 +2,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#e31e24">
     <link rel="stylesheet" type="text/css" href="/main.css" />
     <link rel="icon" type="image/png" href="/images/soupault_icon.png">
     <title> </title>


### PR DESCRIPTION
Modern browsers support `theme-color` which can be used to change the
title bar of the of the browser. This is common on Android’s default
browsers and Vivaldi, but some web extensions like VivaldiFox.
`::selection` the text selection color when dragging over content. In
both of these cases, I chose the horse head’s mane’s red to contrast the
more-common orange color on the site (used on hyperlinks) which helps stikes
the 50/50 balance of the logo’s two dominate colors. (without `theme-color`
VivaldiFox picked the brown of the pole which just doesn’t look nice).

I believe these changes help unify the aesthetic.

I also removed an unused CSS variable changed the red in the dark theme to
match the main (I think there may have been an oversight whereas the orange
on light theme is darker to provide better contrast).